### PR TITLE
Change type of JSON object field `.foo` in `/foo` handler

### DIFF
--- a/web.go
+++ b/web.go
@@ -23,5 +23,5 @@ func hello(res http.ResponseWriter, req *http.Request) {
 }
 
 func foo(res http.ResponseWriter, req *http.Request) {
-    fmt.Fprintln(res, "{\"foo\":\"baz\"}")
+    fmt.Fprintln(res, "{\"foo\":true}")
 }


### PR DESCRIPTION
In this (example) pull request, proposed changes to the `/foo` controller have **failed the JSON schema validation** test:

![Go Heroku example failing JSON schema validation](https://cloud.githubusercontent.com/assets/526560/25151027/a34fcd84-2449-11e7-989b-c8c04bd1d331.png)