### PR TITLE
Heroku Release Phase bug

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: ./release-tasks.sh
 web: go-heroku-example

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in {1..300}
+do
+   echo $i
+   sleep 1
+done
+echo DONE


### PR DESCRIPTION
`release` phase task defined in `Procfile` are run before the app is
made available.  If a task fails, the new release is not deployed.

However, the GitHub deploy status is set to "success" before any
releases task are run.  This has two consequences:

1. The GitHub deploy status does not accurately reflect the outcome of
   the release.
2. Assertible will run before the app is deployed.  So Assertible will
   either use a stale release, or fail if there was no previous release.

https://devcenter.heroku.com/articles/release-phase